### PR TITLE
output without running

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -327,6 +327,15 @@ public class IntegrationTestMojo
     private Long runOrderRandomSeed;
 
     /**
+     * Sets this to true to get the order of test class and methods without having to wait for tests to run.
+     * Useful when some projects would take hours to run the tests.
+     * .
+     * @since 3.0.0-M6
+     */
+    @Parameter( property = "surefire.outputWithoutRunning",  defaultValue = "false" )
+    private boolean outputWithoutRunning;
+
+    /**
      * A file containing include patterns, each in a next line. Blank lines, or lines starting with # are ignored.
      * If {@code includes} are also specified, these patterns are appended. Example with path, simple and regex
      * includes:
@@ -933,6 +942,18 @@ public class IntegrationTestMojo
     public void setRunOrderRandomSeed( Long runOrderRandomSeed )
     {
         this.runOrderRandomSeed = runOrderRandomSeed;
+    }
+
+    @Override
+    public boolean isOutputWithoutRunning()
+    {
+        return outputWithoutRunning;
+    }
+
+    @Override
+    public void setOutputWithoutRunning( boolean outputWithoutRunning )
+    {
+        this.outputWithoutRunning = outputWithoutRunning;
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -867,6 +867,10 @@ public abstract class AbstractSurefireMojo
 
     public abstract void setRunOrder( String runOrder );
 
+    public abstract boolean isOutputWithoutRunning();
+
+    public abstract void setOutputWithoutRunning( boolean outputWithoutRunning );
+
     public abstract Long getRunOrderRandomSeed();
 
     public abstract void setRunOrderRandomSeed( Long runOrderRandomSeed );
@@ -1901,14 +1905,14 @@ public abstract class AbstractSurefireMojo
         }
 
         Map<String, String> providerProperties = toStringProperties( getProperties() );
-
+        boolean outputWithoutRunning = isOutputWithoutRunning();
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, actualFailIfNoTests,
                                           reporterConfiguration,
                                           testNg, // Not really used in provider. Limited to de/serializer.
                                           testSuiteDefinition, providerProperties, null,
                                           false, cli, getSkipAfterFailureCount(),
                                           Shutdown.parameterOf( getShutdown() ),
-                                          getForkedProcessExitTimeoutInSeconds() );
+                                          getForkedProcessExitTimeoutInSeconds(), isOutputWithoutRunning() );
     }
 
     private static Map<String, String> toStringProperties( Properties properties )

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireExecutionParameters.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireExecutionParameters.java
@@ -129,6 +129,8 @@ public interface SurefireExecutionParameters
 
     int getSkipAfterFailureCount();
 
+    boolean isOutputWithoutRunning();
+
     String getShutdown();
 
     String[] getIncludeJUnit5Engines();

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -58,6 +58,7 @@ import static org.apache.maven.surefire.booter.BooterConstants.PLUGIN_PID;
 import static org.apache.maven.surefire.booter.BooterConstants.PROCESS_CHECKER;
 import static org.apache.maven.surefire.booter.BooterConstants.PROVIDER_CONFIGURATION;
 import static org.apache.maven.surefire.booter.BooterConstants.RUN_ORDER_RANDOM_SEED;
+import static org.apache.maven.surefire.booter.BooterConstants.OUTPUT_WITHOUT_RUNNING;
 import static org.apache.maven.surefire.booter.BooterConstants.REPORTSDIRECTORY;
 import static org.apache.maven.surefire.booter.BooterConstants.REQUESTEDTEST;
 import static org.apache.maven.surefire.booter.BooterConstants.RERUN_FAILING_TESTS_COUNT;
@@ -179,6 +180,7 @@ class BooterSerializer
         properties.setProperty( PROVIDER_CONFIGURATION, startupConfiguration.getProviderClassName() );
         properties.setProperty( FAIL_FAST_COUNT, toString( providerConfiguration.getSkipAfterFailureCount() ) );
         properties.setProperty( SHUTDOWN, providerConfiguration.getShutdown().name() );
+        properties.setProperty( OUTPUT_WITHOUT_RUNNING, toString( providerConfiguration.isOutputWithoutRunning() ) );
         List<CommandLineOption> mainCliOptions = providerConfiguration.getMainCliOptions();
         if ( mainCliOptions != null )
         {

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -873,6 +873,18 @@ public class AbstractSurefireMojoJava7PlusTest
         }
 
         @Override
+        public boolean isOutputWithoutRunning()
+        {
+            return false;
+        }
+
+        @Override
+        public void setOutputWithoutRunning( boolean outputWithoutRunning )
+        {
+
+        }
+
+        @Override
         protected void handleSummary( RunResult summary, Exception firstForkException )
         {
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -2423,6 +2423,18 @@ public class AbstractSurefireMojoTest
         }
 
         @Override
+        public boolean isOutputWithoutRunning()
+        {
+            return false;
+        }
+
+        @Override
+        public void setOutputWithoutRunning( boolean outputWithoutRunning )
+        {
+
+        }
+
+        @Override
         protected void handleSummary( RunResult summary, Exception firstForkException )
         {
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
@@ -722,6 +722,18 @@ public class MojoMocklessTest
         }
 
         @Override
+        public boolean isOutputWithoutRunning()
+        {
+            return false;
+        }
+
+        @Override
+        public void setOutputWithoutRunning( boolean outputWithoutRunning )
+        {
+
+        }
+
+        @Override
         public String[] getDependenciesToScan()
         {
             return dependenciesToScan;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -279,7 +279,7 @@ public class BooterDeserializerProviderConfigurationTest
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), TEST_TYPED,
-                readTestsFromInStream, cli, 0, Shutdown.DEFAULT, 0 );
+                readTestsFromInStream, cli, 0, Shutdown.DEFAULT, 0, false );
     }
 
     private StartupConfiguration getTestStartupConfiguration( ClassLoaderConfiguration classLoaderConfiguration )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
@@ -200,7 +200,7 @@ public class BooterDeserializerStartupConfigurationTest
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(),
-                BooterDeserializerProviderConfigurationTest.TEST_TYPED, true, cli, 0, Shutdown.DEFAULT, 0 );
+                BooterDeserializerProviderConfigurationTest.TEST_TYPED, true, cli, 0, Shutdown.DEFAULT, 0, false );
     }
 
     private StartupConfiguration getTestStartupConfiguration( ClassLoaderConfiguration classLoaderConfiguration )

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -319,6 +319,15 @@ public class SurefirePlugin
     private Long runOrderRandomSeed;
 
     /**
+     * Sets this to true to get the order of test class and methods without having to wait for tests to run.
+     * Useful when some projects would take hours to run the tests.
+     * .
+     * @since 3.0.0-M6
+     */
+    @Parameter( property = "surefire.outputWithoutRunning",  defaultValue = "false" )
+    private boolean outputWithoutRunning;
+
+    /**
      * A file containing include patterns. Blank lines, or lines starting with # are ignored. If {@code includes} are
      * also specified, these patterns are appended. Example with path, simple and regex includes:
      * <pre><code>
@@ -858,6 +867,18 @@ public class SurefirePlugin
     public void setRunOrderRandomSeed( Long runOrderRandomSeed )
     {
         this.runOrderRandomSeed = runOrderRandomSeed;
+    }
+
+    @Override
+    public boolean isOutputWithoutRunning()
+    {
+        return outputWithoutRunning;
+    }
+
+    @Override
+    public void setOutputWithoutRunning( boolean outputWithoutRunning )
+    {
+        this.outputWithoutRunning = outputWithoutRunning;
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/BaseProviderFactory.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/BaseProviderFactory.java
@@ -73,6 +73,8 @@ public class BaseProviderFactory
 
     private int skipAfterFailureCount;
 
+    private boolean outputWithoutRunning;
+
     private Integer systemExitTimeout;
 
     private CommandChainReader commandReader;
@@ -234,6 +236,12 @@ public class BaseProviderFactory
         return skipAfterFailureCount;
     }
 
+    @Override
+    public boolean isOutputWithoutRunning()
+    {
+        return outputWithoutRunning;
+    }
+
     /**
      * See the plugin configuration parameter "skipAfterFailureCount".
      *
@@ -264,5 +272,10 @@ public class BaseProviderFactory
     public void setForkedChannelEncoder( MasterProcessChannelEncoder masterProcessChannelEncoder )
     {
         this.masterProcessChannelEncoder = masterProcessChannelEncoder;
+    }
+
+    public void setOutputWithoutRunning( boolean outputWithoutRunning )
+    {
+        this.outputWithoutRunning = outputWithoutRunning;
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/provider/ProviderParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/provider/ProviderParameters.java
@@ -139,6 +139,8 @@ public interface ProviderParameters
      */
     int getSkipAfterFailureCount();
 
+    boolean isOutputWithoutRunning();
+
     /**
      * @return {@code true} if test provider appears in forked jvm; Otherwise {@code false} means
      * in-plugin provider.

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -46,6 +46,7 @@ public final class BooterConstants
     public static final String TEST_CLASSES_DIRECTORY = "testClassesDirectory";
     public static final String RUN_ORDER = "runOrder";
     public static final String RUN_ORDER_RANDOM_SEED = "runOrderRandomSeed";
+    public static final String OUTPUT_WITHOUT_RUNNING = "outputWithoutRunning";
     public static final String RUN_STATISTICS_FILE = "runStatisticsFile";
     public static final String TEST_SUITE_XML_FILES = "testSuiteXmlFiles";
     public static final String PROVIDER_CONFIGURATION = "providerConfiguration";

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -96,6 +96,8 @@ public class BooterDeserializer
         final TypeEncodedValue typeEncodedTestForFork = properties.getTypeEncodedValue( FORKTESTSET );
         final boolean preferTestsFromInStream =
             properties.getBooleanProperty( FORKTESTSET_PREFER_TESTS_FROM_IN_STREAM );
+        final boolean outputWithoutRunning =
+            properties.getBooleanProperty( OUTPUT_WITHOUT_RUNNING );
 
         final String requestedTest = properties.getProperty( REQUESTEDTEST );
         final File sourceDirectory = properties.getFileProperty( SOURCE_DIRECTORY );
@@ -142,7 +144,7 @@ public class BooterDeserializer
                                           properties.getBooleanProperty( FAILIFNOTESTS ), reporterConfiguration, testNg,
                                           testSuiteDefinition, properties.getProperties(), typeEncodedTestForFork,
                                           preferTestsFromInStream, fromStrings( cli ), failFastCount, shutdown,
-                                          systemExitTimeout );
+                                          systemExitTimeout, outputWithoutRunning );
     }
 
     public StartupConfiguration getStartupConfiguration()

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
@@ -494,6 +494,7 @@ public final class ForkedBooter
         bpf.setDirectoryScannerParameters( providerConfiguration.getDirScannerParams() );
         bpf.setMainCliOptions( providerConfiguration.getMainCliOptions() );
         bpf.setSkipAfterFailureCount( providerConfiguration.getSkipAfterFailureCount() );
+        bpf.setOutputWithoutRunning( providerConfiguration.isOutputWithoutRunning() );
         bpf.setSystemExitTimeout( providerConfiguration.getSystemExitTimeout() );
         String providerClass = startupConfiguration.getActualClassName();
         return instantiateOneArg( classLoader, providerClass, ProviderParameters.class, bpf );

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderConfiguration.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderConfiguration.java
@@ -64,6 +64,8 @@ public class ProviderConfiguration
 
     private final int skipAfterFailureCount;
 
+    private final boolean outputWithoutRunning;
+
     private final Shutdown shutdown;
 
     private final Integer systemExitTimeout;
@@ -75,7 +77,7 @@ public class ProviderConfiguration
                                   TestRequest testSuiteDefinition, Map<String, String> providerProperties,
                                   TypeEncodedValue typeEncodedTestSet, boolean readTestsFromInStream,
                                   List<CommandLineOption> mainCliOptions, int skipAfterFailureCount,
-                                  Shutdown shutdown, Integer systemExitTimeout )
+                                  Shutdown shutdown, Integer systemExitTimeout, boolean outputWithoutRunning )
     {
         this.runOrderParameters = runOrderParameters;
         this.providerProperties = providerProperties;
@@ -90,6 +92,7 @@ public class ProviderConfiguration
         this.skipAfterFailureCount = skipAfterFailureCount;
         this.shutdown = shutdown;
         this.systemExitTimeout = systemExitTimeout;
+        this.outputWithoutRunning = outputWithoutRunning;
     }
 
     public ReporterConfiguration getReporterConfiguration()
@@ -162,6 +165,11 @@ public class ProviderConfiguration
     public int getSkipAfterFailureCount()
     {
         return skipAfterFailureCount;
+    }
+
+    public boolean isOutputWithoutRunning()
+    {
+        return outputWithoutRunning;
     }
 
     public Shutdown getShutdown()

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -96,6 +96,8 @@ public class JUnit4Provider
 
     private TestsToRun testsToRun;
 
+    private static boolean outputWithoutRunning = false;
+
     public JUnit4Provider( ProviderParameters bootParams )
     {
         // don't start a thread in CommandReader while we are in in-plugin process
@@ -109,6 +111,7 @@ public class JUnit4Provider
         TestRequest testRequest = bootParams.getTestRequest();
         testResolver = testRequest.getTestListResolver();
         rerunFailingTestsCount = testRequest.getRerunFailingTestsCount();
+        outputWithoutRunning = bootParams.isOutputWithoutRunning();
     }
 
     @Override
@@ -374,7 +377,7 @@ public class JUnit4Provider
                 request = request.filterWith( filter );
             }
             Runner runner = request.getRunner();
-            if ( countTestsInRunner( runner.getDescription() ) != 0 )
+            if ( countTestsInRunner( runner.getDescription() ) != 0 && !outputWithoutRunning )
             {
                 runner.run( notifier );
             }


### PR DESCRIPTION
With `-Dsurefire.outputWithoutRunning=true`  order of class and methods are printed as normal while no tests are actually to run.