### PR TITLE
add support for rerun regardless of failing test or not

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -272,6 +272,15 @@ public class IntegrationTestMojo
     private int rerunFailingTestsCount;
 
     /**
+     * Rerun the whole test regardless of whether the result is failure or not.
+     * Used to detect flaky test that have been passed the first run.
+     * Enable with system property {@code -Dsurefire.rerunRegardlessCount=1} or any number greater than zero.
+     * @since 3.0.0-M6
+     */
+    @Parameter( property = "surefire.rerunRegardlessCount", defaultValue = "0" )
+    private int rerunRegardlessCount;
+
+    /**
      * (TestNG) List of &lt;suiteXmlFile&gt; elements specifying TestNG suite xml file locations. Note that
      * {@code suiteXmlFiles} is incompatible with several other parameters of this plugin, like
      * {@code includes} and {@code excludes}.<br>
@@ -464,6 +473,12 @@ public class IntegrationTestMojo
     protected int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    @Override
+    protected int getRerunRegardlessCount()
+    {
+        return rerunRegardlessCount;
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -832,6 +832,9 @@ public abstract class AbstractSurefireMojo
 
     protected abstract int getRerunFailingTestsCount();
 
+    protected abstract int getRerunRegardlessCount();
+
+
     @Override
     public abstract List<String> getIncludes();
 
@@ -1820,7 +1823,8 @@ public abstract class AbstractSurefireMojo
         final TestRequest testSuiteDefinition = new TestRequest( suiteXmlFiles(),
                                                                  getTestSourceDirectory(),
                                                                  getSpecificTests(),
-                                                                 getRerunFailingTestsCount() );
+                                                                 getRerunFailingTestsCount(),
+                                                                 getRerunRegardlessCount() );
 
         final boolean actualFailIfNoTests;
         DirectoryScannerParameters directoryScannerParameters = null;
@@ -2137,7 +2141,8 @@ public abstract class AbstractSurefireMojo
                                                getReportsDirectory(), isTrimStackTrace(), getReportNameSuffix(),
                                                getStatisticsFile( configChecksum ), requiresRunHistory(),
                                                getRerunFailingTestsCount(), getReportSchemaLocation(), getEncoding(),
-                                               isForkMode, xmlReporter, outReporter, testsetReporter );
+                                               isForkMode, xmlReporter, outReporter, testsetReporter,
+                                               getRerunRegardlessCount() );
     }
 
     private boolean isSpecificTestSpecified()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
@@ -78,6 +78,8 @@ public final class StartupReportConfiguration
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunRegardlessCount;
+
     private final String xsdSchemaLocation;
 
     private final Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new ConcurrentHashMap<>();
@@ -101,7 +103,7 @@ public final class StartupReportConfiguration
                File statisticsFile, boolean requiresRunHistory, int rerunFailingTestsCount,
                String xsdSchemaLocation, String encoding, boolean isForkMode,
                SurefireStatelessReporter xmlReporter, SurefireConsoleOutputReporter consoleOutputReporter,
-               SurefireStatelessTestsetInfoReporter testsetReporter )
+               SurefireStatelessTestsetInfoReporter testsetReporter, int rerunRegardlessCount )
     {
         this.useFile = useFile;
         this.printSummary = printSummary;
@@ -115,6 +117,7 @@ public final class StartupReportConfiguration
         this.originalSystemOut = System.out;
         this.originalSystemErr = System.err;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
+        this.rerunRegardlessCount = rerunRegardlessCount;
         this.xsdSchemaLocation = xsdSchemaLocation;
         String charset = trimToNull( encoding );
         this.encoding = charset == null ? UTF_8 : Charset.forName( charset );
@@ -159,6 +162,11 @@ public final class StartupReportConfiguration
         return rerunFailingTestsCount;
     }
 
+    public int getRerunRegardlessCount()
+    {
+        return rerunRegardlessCount;
+    }
+
     public StatelessReportEventListener<WrappedReportEntry, TestSetStats> instantiateStatelessXmlReporter(
             Integer forkNumber )
     {
@@ -175,7 +183,8 @@ public final class StartupReportConfiguration
 
         DefaultStatelessReportMojoConfiguration xmlReporterConfig =
                 new DefaultStatelessReportMojoConfiguration( resolveReportsDirectory( forkNumber ), reportNameSuffix,
-                        trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation, testClassMethodRunHistory );
+                        trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation, testClassMethodRunHistory,
+                    rerunRegardlessCount );
 
         return xmlReporter.isDisable() ? null : xmlReporter.createListener( xmlReporterConfig );
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -59,6 +59,7 @@ import static org.apache.maven.surefire.booter.BooterConstants.PROVIDER_CONFIGUR
 import static org.apache.maven.surefire.booter.BooterConstants.REPORTSDIRECTORY;
 import static org.apache.maven.surefire.booter.BooterConstants.REQUESTEDTEST;
 import static org.apache.maven.surefire.booter.BooterConstants.RERUN_FAILING_TESTS_COUNT;
+import static org.apache.maven.surefire.booter.BooterConstants.RERUN_REGARDLESS_COUNT;
 import static org.apache.maven.surefire.booter.BooterConstants.RUN_ORDER;
 import static org.apache.maven.surefire.booter.BooterConstants.RUN_STATISTICS_FILE;
 import static org.apache.maven.surefire.booter.BooterConstants.SHUTDOWN;
@@ -144,6 +145,8 @@ class BooterSerializer
             properties.setProperty( REQUESTEDTEST, testFilter == null ? "" : testFilter.getPluginParameterTest() );
             int rerunFailingTestsCount = testSuiteDefinition.getRerunFailingTestsCount();
             properties.setNullableProperty( RERUN_FAILING_TESTS_COUNT, toString( rerunFailingTestsCount ) );
+            int rerunRegardlessCount = testSuiteDefinition.getRerunRegardlessCount();
+            properties.setNullableProperty( RERUN_REGARDLESS_COUNT, toString( rerunRegardlessCount ) );
         }
 
         DirectoryScannerParameters directoryScannerParameters = providerConfiguration.getDirScannerParams();

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/DefaultStatelessReportMojoConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/DefaultStatelessReportMojoConfiguration.java
@@ -45,9 +45,11 @@ public class DefaultStatelessReportMojoConfiguration
                                                     boolean trimStackTrace,
                                                     int rerunFailingTestsCount,
                                                     String xsdSchemaLocation,
-                                                    Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory )
+                                                    Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory,
+                                                    int rerunRegardlessCount )
     {
-        super( reportsDirectory, reportNameSuffix, trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation );
+        super( reportsDirectory, reportNameSuffix, trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation,
+            rerunRegardlessCount );
         this.testClassMethodRunHistory = testClassMethodRunHistory;
     }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireStatelessReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireStatelessReporter.java
@@ -72,7 +72,8 @@ public class SurefireStatelessReporter
                 false,
                 false,
                 false,
-                false );
+                false,
+                configuration.getRerunRegardlessCount() );
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5Xml30StatelessReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5Xml30StatelessReporter.java
@@ -118,7 +118,8 @@ public class JUnit5Xml30StatelessReporter
                 getUsePhrasedFileName(),
                 getUsePhrasedTestSuiteClassName(),
                 getUsePhrasedTestCaseClassName(),
-                getUsePhrasedTestCaseMethodName() );
+                getUsePhrasedTestCaseMethodName(),
+                configuration.getRerunFailingTestsCount() );
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -226,7 +226,8 @@ public class DefaultReporterFactory
      * @return the type of test result
      */
     // Use default visibility for testing
-    static TestResultType getTestResultType( List<ReportEntryType> reportEntries, int rerunFailingTestsCount  )
+    static TestResultType getTestResultType( List<ReportEntryType> reportEntries, int rerunFailingTestsCount,
+                                             int rerunRegardlessCount )
     {
         if ( reportEntries == null || reportEntries.isEmpty() )
         {
@@ -252,7 +253,7 @@ public class DefaultReporterFactory
 
         if ( seenFailure || seenError )
         {
-            if ( seenSuccess && rerunFailingTestsCount > 0 )
+            if ( seenSuccess && ( rerunFailingTestsCount > 0 || rerunRegardlessCount > 0 ) )
             {
                 return flake;
             }
@@ -318,7 +319,8 @@ public class DefaultReporterFactory
                 resultTypes.add( methodStats.getResultType() );
             }
 
-            switch ( getTestResultType( resultTypes, reportConfiguration.getRerunFailingTestsCount() ) )
+            switch ( getTestResultType( resultTypes, reportConfiguration.getRerunFailingTestsCount(),
+                reportConfiguration.getRerunRegardlessCount() ) )
             {
                 case success:
                     // If there are multiple successful runs of the same test, count all of them

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
@@ -33,7 +33,7 @@ class NullStatelessXmlReporter
 
     private NullStatelessXmlReporter()
     {
-        super( null, null, false, 0, null, null, null, false, false, false, false );
+        super( null, null, false, 0, null, null, null, false, false, false, false, 0 );
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportEntryType.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportEntryType.java
@@ -29,7 +29,7 @@ public enum ReportEntryType
     ERROR( "error", "flakyError", "rerunError" ),
     FAILURE( "failure", "flakyFailure", "rerunFailure" ),
     SKIPPED( "skipped", "", "" ),
-    SUCCESS( "", "", "" );
+    SUCCESS( "success", "rerunSuccess", "rerunSuccess" );
 
     private final String xmlTag;
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -522,6 +522,12 @@ public class AbstractSurefireMojoJava7PlusTest
         }
 
         @Override
+        protected int getRerunRegardlessCount()
+        {
+            return 0;
+        }
+
+        @Override
         public boolean isSkipTests()
         {
             return false;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -2052,6 +2052,12 @@ public class AbstractSurefireMojoTest
         }
 
         @Override
+        protected int getRerunRegardlessCount()
+        {
+            return 0;
+        }
+
+        @Override
         public boolean isSkipTests()
         {
             return false;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
@@ -73,7 +73,7 @@ public class CommonReflectorTest
 
         startupReportConfiguration = new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory,
                 false, null, statistics, false, 1, null, null, false,
-                xmlReporter, consoleOutputReporter, infoReporter );
+                xmlReporter, consoleOutputReporter, infoReporter, 0 );
 
         consoleLogger = mock( ConsoleLogger.class );
     }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
@@ -392,6 +392,12 @@ public class MojoMocklessTest
         }
 
         @Override
+        protected int getRerunRegardlessCount()
+        {
+            return 0;
+        }
+
+        @Override
         public boolean isSkipTests()
         {
             return false;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -275,7 +275,7 @@ public class BooterDeserializerProviderConfigurationTest
         TestRequest testSuiteDefinition =
             new TestRequest( getSuiteXmlFileStrings(), getTestSourceDirectory(),
                              new TestListResolver( USER_REQUESTED_TEST + "#aUserRequestedTestMethod" ),
-                    RERUN_FAILING_TEST_COUNT );
+                    RERUN_FAILING_TEST_COUNT, 0 );
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), TEST_TYPED,

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
@@ -156,7 +156,7 @@ public class ForkStarterTest
             .thenReturn( cli );
 
         StartupReportConfiguration startupReportConfiguration = new StartupReportConfiguration( true, true, null,
-            false, tmp, true, "", null, false, 0, null, null, true, null, null, null );
+            false, tmp, true, "", null, false, 0, null, null, true, null, null, null, 0 );
 
         ConsoleLogger logger = mock( ConsoleLogger.class );
 
@@ -215,7 +215,7 @@ public class ForkStarterTest
             .thenReturn( cli );
 
         StartupReportConfiguration startupReportConfiguration = new StartupReportConfiguration( true, true, null,
-            false, tmp, true, "", null, false, 0, null, null, true, null, null, null );
+            false, tmp, true, "", null, false, 0, null, null, true, null, null, null, 0 );
 
         ConsoleLogger logger = mock( ConsoleLogger.class );
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
@@ -60,6 +60,6 @@ public class TestSetMockReporterFactory
         File statisticsFile = new File( target, "TESTHASH" );
         return new StartupReportConfiguration( true, true, "PLAIN", false, target, false, null, statisticsFile,
                 false, 0, null, null, true, new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                new SurefireStatelessTestsetInfoReporter() );
+                new SurefireStatelessTestsetInfoReporter(), 0 );
     }
 }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StatelessReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StatelessReporterTest.java
@@ -78,7 +78,7 @@ public class StatelessReporterTest
         Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new HashMap<>();
         DefaultStatelessReportMojoConfiguration config =
                 new DefaultStatelessReportMojoConfiguration( reportsDirectory, reportNameSuffix, true, 5, schema,
-                        testClassMethodRunHistory );
+                        testClassMethodRunHistory, 0 );
         SurefireStatelessReporter extension = new SurefireStatelessReporter();
 
         assertThat( extension.getVersion() )
@@ -175,7 +175,7 @@ public class StatelessReporterTest
         Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new HashMap<>();
         DefaultStatelessReportMojoConfiguration config =
                 new DefaultStatelessReportMojoConfiguration( reportsDirectory, reportNameSuffix, true, 5, schema,
-                        testClassMethodRunHistory );
+                        testClassMethodRunHistory, 0 );
         JUnit5Xml30StatelessReporter extension = new JUnit5Xml30StatelessReporter();
 
         assertThat( extension.getVersion() )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -84,7 +84,7 @@ public class DefaultReporterFactoryTest
                 new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory, false, null,
                         new File( reportsDirectory, "TESTHASH" ), false, 1, null, null, false,
                         new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                        new SurefireStatelessTestsetInfoReporter() );
+                        new SurefireStatelessTestsetInfoReporter(), 0 );
 
         DummyTestReporter reporter = new DummyTestReporter();
 
@@ -234,41 +234,41 @@ public class DefaultReporterFactoryTest
     public void testGetTestResultType()
     {
         List<ReportEntryType> emptyList = new ArrayList<>();
-        assertEquals( unknown, getTestResultType( emptyList, 1 ) );
+        assertEquals( unknown, getTestResultType( emptyList, 1, 0 ) );
 
         List<ReportEntryType> successList = new ArrayList<>();
         successList.add( ReportEntryType.SUCCESS );
         successList.add( ReportEntryType.SUCCESS );
-        assertEquals( success, getTestResultType( successList, 1 ) );
+        assertEquals( success, getTestResultType( successList, 1, 0 ) );
 
         List<ReportEntryType> failureErrorList = new ArrayList<>();
         failureErrorList.add( ReportEntryType.FAILURE );
         failureErrorList.add( ReportEntryType.ERROR );
-        assertEquals( error, getTestResultType( failureErrorList, 1 ) );
+        assertEquals( error, getTestResultType( failureErrorList, 1, 0 ) );
 
         List<ReportEntryType> errorFailureList = new ArrayList<>();
         errorFailureList.add( ReportEntryType.ERROR );
         errorFailureList.add( ReportEntryType.FAILURE );
-        assertEquals( error, getTestResultType( errorFailureList, 1 ) );
+        assertEquals( error, getTestResultType( errorFailureList, 1, 0 ) );
 
         List<ReportEntryType> flakeList = new ArrayList<>();
         flakeList.add( ReportEntryType.SUCCESS );
         flakeList.add( ReportEntryType.FAILURE );
-        assertEquals( flake, getTestResultType( flakeList, 1 ) );
+        assertEquals( flake, getTestResultType( flakeList, 1, 0 ) );
 
-        assertEquals( failure, getTestResultType( flakeList, 0 ) );
+        assertEquals( failure, getTestResultType( flakeList, 0, 0 ) );
 
         flakeList = new ArrayList<>();
         flakeList.add( ReportEntryType.ERROR );
         flakeList.add( ReportEntryType.SUCCESS );
         flakeList.add( ReportEntryType.FAILURE );
-        assertEquals( flake, getTestResultType( flakeList, 1 ) );
+        assertEquals( flake, getTestResultType( flakeList, 1, 0 ) );
 
-        assertEquals( error, getTestResultType( flakeList, 0 ) );
+        assertEquals( error, getTestResultType( flakeList, 0, 0 ) );
 
         List<ReportEntryType> skippedList = new ArrayList<>();
         skippedList.add( ReportEntryType.SKIPPED );
-        assertEquals( skipped, getTestResultType( skippedList, 1 ) );
+        assertEquals( skipped, getTestResultType( skippedList, 1, 0 ) );
     }
 
     public void testLogger()
@@ -280,7 +280,7 @@ public class DefaultReporterFactoryTest
                 new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory, false, null,
                         new File( reportsDirectory, "TESTHASH" ), false, 1, null, null, false,
                         new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                        new SurefireStatelessTestsetInfoReporter() );
+                        new SurefireStatelessTestsetInfoReporter(), 0 );
 
         DummyTestReporter reporter = new DummyTestReporter();
 
@@ -333,7 +333,7 @@ public class DefaultReporterFactoryTest
                 new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory, false, null,
                         new File( reportsDirectory, "TESTHASH" ), false, 0, null, null, false,
                         new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                        new SurefireStatelessTestsetInfoReporter() );
+                        new SurefireStatelessTestsetInfoReporter(), 0 );
 
         assertTrue( reportConfig.isUseFile() );
         assertTrue( reportConfig.isPrintSummary() );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -88,7 +88,8 @@ public class StatelessXmlReporterTest
         StatelessXmlReporter reporter =
                 new StatelessXmlReporter( reportDir, null, false, 0,
                         new ConcurrentHashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0",
-                        false, false, false, false );
+                        false, false, false, false,
+                        0 );
         reporter.cleanTestHistoryMap();
 
         ReportEntry reportEntry = new SimpleReportEntry( getClass().getName(), null, getClass().getName(), null, 12 );
@@ -138,7 +139,7 @@ public class StatelessXmlReporterTest
 
         stats.testSucceeded( t2 );
         StatelessXmlReporter reporter = new StatelessXmlReporter( reportDir, null, false, 0,
-                new ConcurrentHashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false, false, false, false );
+                new ConcurrentHashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false, false, false, false, 0 );
         reporter.testSetCompleted( testSetReportEntry, stats );
 
         FileInputStream fileInputStream = new FileInputStream( expectedReportFile );
@@ -217,7 +218,7 @@ public class StatelessXmlReporterTest
 
         StatelessXmlReporter reporter =
                 new StatelessXmlReporter( reportDir, null, false, 1,
-                        new HashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false, false, false, false );
+                        new HashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false, false, false, false, 0 );
 
         reporter.testSetCompleted( testSetReportEntry, stats );
         reporter.testSetCompleted( testSetReportEntry, rerunStats );

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -254,6 +254,15 @@ public class SurefirePlugin
     private int rerunFailingTestsCount;
 
     /**
+     * Rerun the whole test regardless of whether the result is failure or not.
+     * Used to detect flaky test that have been passed the first run.
+     * Enable with system property {@code -Dsurefire.rerunRegardlessCount=1} or any number greater than zero.
+     * @since 3.0.0-M6
+     */
+    @Parameter( property = "surefire.rerunRegardlessCount", defaultValue = "0" )
+    private int rerunRegardlessCount;
+
+    /**
      * (TestNG) List of &lt;suiteXmlFile&gt; elements specifying TestNG suite xml file locations. Note that
      * {@code suiteXmlFiles} is incompatible with several other parameters of this plugin, like
      * {@code includes} and {@code excludes}.<br>
@@ -444,6 +453,12 @@ public class SurefirePlugin
     protected int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    @Override
+    protected int getRerunRegardlessCount()
+    {
+        return rerunRegardlessCount;
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/testset/TestRequest.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/testset/TestRequest.java
@@ -38,18 +38,21 @@ public class TestRequest
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunRegardlessCount;
+
     public TestRequest( List suiteXmlFiles, File testSourceDirectory, TestListResolver requestedTests )
     {
-        this( createFiles( suiteXmlFiles ), testSourceDirectory, requestedTests, 0 );
+        this( createFiles( suiteXmlFiles ), testSourceDirectory, requestedTests, 0, 0 );
     }
 
     public TestRequest( List suiteXmlFiles, File testSourceDirectory, TestListResolver requestedTests,
-                        int rerunFailingTestsCount )
+                        int rerunFailingTestsCount, int rerunRegardlessCount )
     {
         this.suiteXmlFiles = createFiles( suiteXmlFiles );
         this.testSourceDirectory = testSourceDirectory;
         this.requestedTests = requestedTests;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
+        this.rerunRegardlessCount = rerunRegardlessCount;
     }
 
     /**
@@ -90,6 +93,11 @@ public class TestRequest
     public int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    public int getRerunRegardlessCount()
+    {
+        return rerunRegardlessCount;
     }
 
     private static List<File> createFiles( List suiteXmlFiles )

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -52,6 +52,7 @@ public final class BooterConstants
     public static final String FORKTESTSET = "forkTestSet";
     public static final String FORKTESTSET_PREFER_TESTS_FROM_IN_STREAM = "preferTestsFromInStream";
     public static final String RERUN_FAILING_TESTS_COUNT = "rerunFailingTestsCount";
+    public static final String RERUN_REGARDLESS_COUNT = "rerunRegardlessCount";
     public static final String MAIN_CLI_OPTIONS = "mainCliOptions";
     public static final String FAIL_FAST_COUNT = "failFastCount";
     public static final String SHUTDOWN = "shutdown";

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -105,6 +105,7 @@ public class BooterDeserializer
         final String runStatisticsFile = properties.getProperty( RUN_STATISTICS_FILE );
 
         final int rerunFailingTestsCount = properties.getIntProperty( RERUN_FAILING_TESTS_COUNT );
+        final int rerunRegardlessCount = properties.getIntProperty( RERUN_REGARDLESS_COUNT );
 
         DirectoryScannerParameters dirScannerParams =
             new DirectoryScannerParameters( testClassesDirectory, includes, excludes, specificTests,
@@ -116,7 +117,7 @@ public class BooterDeserializer
         TestArtifactInfo testNg = new TestArtifactInfo( testNgVersion, testArtifactClassifier );
         TestRequest testSuiteDefinition =
             new TestRequest( testSuiteXmlFiles, sourceDirectory, new TestListResolver( requestedTest ),
-                             rerunFailingTestsCount );
+                             rerunFailingTestsCount, rerunRegardlessCount );
 
         ReporterConfiguration reporterConfiguration =
             new ReporterConfiguration( reportsDirectory, properties.getBooleanProperty( ISTRIMSTACKTRACE ) );

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportMojoConfiguration.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportMojoConfiguration.java
@@ -36,16 +36,20 @@ public class StatelessReportMojoConfiguration
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunRegardlessCount;
+
     private final String xsdSchemaLocation;
 
     public StatelessReportMojoConfiguration( File reportsDirectory, String reportNameSuffix, boolean trimStackTrace,
-                                             int rerunFailingTestsCount, String xsdSchemaLocation )
+                                             int rerunFailingTestsCount, String xsdSchemaLocation,
+                                             int rerunRegardlessCount )
     {
         this.reportsDirectory = reportsDirectory;
         this.reportNameSuffix = reportNameSuffix;
         this.trimStackTrace = trimStackTrace;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
         this.xsdSchemaLocation = xsdSchemaLocation;
+        this.rerunRegardlessCount = rerunRegardlessCount;
     }
 
     public File getReportsDirectory()
@@ -66,6 +70,11 @@ public class StatelessReportMojoConfiguration
     public int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    public int getRerunRegardlessCount()
+    {
+        return rerunRegardlessCount;
     }
 
     public String getXsdSchemaLocation()

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -91,6 +91,8 @@ public class JUnit4Provider
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunRegardlessCount;
+
     private final CommandChainReader commandsReader;
 
     private TestsToRun testsToRun;
@@ -108,6 +110,7 @@ public class JUnit4Provider
         TestRequest testRequest = bootParams.getTestRequest();
         testResolver = testRequest.getTestListResolver();
         rerunFailingTestsCount = testRequest.getRerunFailingTestsCount();
+        rerunRegardlessCount = testRequest.getRerunRegardlessCount();
     }
 
     @Override
@@ -192,6 +195,11 @@ public class JUnit4Provider
     private boolean isRerunFailingTests()
     {
         return rerunFailingTestsCount > 0;
+    }
+
+    private boolean isRerunRegardless()
+    {
+        return rerunRegardlessCount > 0;
     }
 
     private boolean isFailFast()
@@ -287,6 +295,16 @@ public class JUnit4Provider
                     failureListener.reset();
                     Filter failureDescriptionFilter = createMatchAnyDescriptionFilter( failures );
                     execute( clazz, rerunNotifier, failureDescriptionFilter );
+                }
+            }
+            else if ( isRerunRegardless() )
+            {
+                Notifier rerunNotifier = pureNotifier();
+                notifier.copyListenersTo( rerunNotifier );
+                for ( int i = 0; i < rerunRegardlessCount ; i++ )
+                {
+                    failureListener.reset();
+                    execute( clazz, rerunNotifier, null );
                 }
             }
         }

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
@@ -109,6 +109,6 @@ public class JUnitCoreTester
         File statisticsFile = new File( target, "TESTHASHxXML" );
         return new StartupReportConfiguration( true, true, "PLAIN", false, target, false, null, statisticsFile,
                 false, 0, null, null, false, new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                new SurefireStatelessTestsetInfoReporter() );
+                new SurefireStatelessTestsetInfoReporter(), 0 );
     }
 }


### PR DESCRIPTION
With  `-Dsurefire.rerunRegardlessCount=5` all the test methods are to rerun 5 times regardless of success or not.
The console output will include flaky if a test both fails and succeeds.
The XML output is changed that it will always print all runs of a testcase.
It is not supported to use both `-Dsurefire.rerunRegardlessCount` and -Dsurefire.rerunFailingTestsCount` at the same time.