### PR TITLE
add support to report all class order in one XML file

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -272,6 +272,13 @@ public class IntegrationTestMojo
     private int rerunFailingTestsCount;
 
     /**
+     * Set this to true to get all XML report printed into TEST-ALLCLASS.xml which consists the order of all test
+     * classes. The property is ommited for concision.
+     */
+    @Parameter( property = "failsafe.reportAllClass", defaultValue = "false" )
+    private boolean reportAllClass;
+
+    /**
      * (TestNG) List of &lt;suiteXmlFile&gt; elements specifying TestNG suite xml file locations. Note that
      * {@code suiteXmlFiles} is incompatible with several other parameters of this plugin, like
      * {@code includes} and {@code excludes}.<br>
@@ -496,6 +503,12 @@ public class IntegrationTestMojo
     protected int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    @Override
+    protected boolean isReportAllClass()
+    {
+        return reportAllClass;
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -834,6 +834,8 @@ public abstract class AbstractSurefireMojo
 
     protected abstract int getRerunFailingTestsCount();
 
+    protected abstract boolean isReportAllClass();
+
     @Override
     public abstract List<String> getIncludes();
 
@@ -2173,13 +2175,13 @@ public abstract class AbstractSurefireMojo
         SurefireStatelessTestsetInfoReporter testsetReporter =
                 statelessTestsetInfoReporter == null
                         ? new SurefireStatelessTestsetInfoReporter() : statelessTestsetInfoReporter;
-
         return new StartupReportConfiguration( isUseFile(), isPrintSummary(), getReportFormat(),
                                                isRedirectTestOutputToFile(),
                                                getReportsDirectory(), isTrimStackTrace(), getReportNameSuffix(),
                                                getStatisticsFile( configChecksum ), requiresRunHistory(),
                                                getRerunFailingTestsCount(), getReportSchemaLocation(), getEncoding(),
-                                               isForkMode, xmlReporter, outReporter, testsetReporter );
+                                               isForkMode, xmlReporter, outReporter, testsetReporter,
+                                               isReportAllClass() );
     }
 
     private boolean isSpecificTestSpecified()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
@@ -76,6 +76,8 @@ public final class StartupReportConfiguration
 
     private final boolean trimStackTrace;
 
+    private final boolean reportAllClass;
+
     private final int rerunFailingTestsCount;
 
     private final String xsdSchemaLocation;
@@ -101,7 +103,7 @@ public final class StartupReportConfiguration
                File statisticsFile, boolean requiresRunHistory, int rerunFailingTestsCount,
                String xsdSchemaLocation, String encoding, boolean isForkMode,
                SurefireStatelessReporter xmlReporter, SurefireConsoleOutputReporter consoleOutputReporter,
-               SurefireStatelessTestsetInfoReporter testsetReporter )
+               SurefireStatelessTestsetInfoReporter testsetReporter, boolean reportAllClass )
     {
         this.useFile = useFile;
         this.printSummary = printSummary;
@@ -122,6 +124,7 @@ public final class StartupReportConfiguration
         this.xmlReporter = xmlReporter;
         this.consoleOutputReporter = consoleOutputReporter;
         this.testsetReporter = testsetReporter;
+        this.reportAllClass = reportAllClass;
     }
 
     public boolean isUseFile()
@@ -175,7 +178,8 @@ public final class StartupReportConfiguration
 
         DefaultStatelessReportMojoConfiguration xmlReporterConfig =
                 new DefaultStatelessReportMojoConfiguration( resolveReportsDirectory( forkNumber ), reportNameSuffix,
-                        trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation, testClassMethodRunHistory );
+                        trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation, testClassMethodRunHistory,
+                    reportAllClass );
 
         return xmlReporter.isDisable() ? null : xmlReporter.createListener( xmlReporterConfig );
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/DefaultStatelessReportMojoConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/DefaultStatelessReportMojoConfiguration.java
@@ -45,9 +45,11 @@ public class DefaultStatelessReportMojoConfiguration
                                                     boolean trimStackTrace,
                                                     int rerunFailingTestsCount,
                                                     String xsdSchemaLocation,
-                                                    Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory )
+                                                    Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory,
+                                                    boolean reportAllClass )
     {
-        super( reportsDirectory, reportNameSuffix, trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation );
+        super( reportsDirectory, reportNameSuffix, trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation,
+            reportAllClass );
         this.testClassMethodRunHistory = testClassMethodRunHistory;
     }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireStatelessReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireStatelessReporter.java
@@ -72,7 +72,8 @@ public class SurefireStatelessReporter
                 false,
                 false,
                 false,
-                false );
+                false,
+                configuration.isReportAllClass() );
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5Xml30StatelessReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5Xml30StatelessReporter.java
@@ -118,7 +118,8 @@ public class JUnit5Xml30StatelessReporter
                 getUsePhrasedFileName(),
                 getUsePhrasedTestSuiteClassName(),
                 getUsePhrasedTestCaseClassName(),
-                getUsePhrasedTestCaseMethodName() );
+                getUsePhrasedTestCaseMethodName(),
+                false );
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
@@ -33,7 +33,7 @@ class NullStatelessXmlReporter
 
     private NullStatelessXmlReporter()
     {
-        super( null, null, false, 0, null, null, null, false, false, false, false );
+        super( null, null, false, 0, null, null, null, false, false, false, false, false );
     }
 
     @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -543,6 +543,12 @@ public class AbstractSurefireMojoJava7PlusTest
         }
 
         @Override
+        protected boolean isReportAllClass()
+        {
+            return false;
+        }
+
+        @Override
         public boolean isSkipTests()
         {
             return false;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -2081,6 +2081,12 @@ public class AbstractSurefireMojoTest
         }
 
         @Override
+        protected boolean isReportAllClass()
+        {
+            return false;
+        }
+
+        @Override
         public boolean isSkipTests()
         {
             return false;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
@@ -73,7 +73,7 @@ public class CommonReflectorTest
 
         startupReportConfiguration = new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory,
                 false, null, statistics, false, 1, null, null, false,
-                xmlReporter, consoleOutputReporter, infoReporter );
+                xmlReporter, consoleOutputReporter, infoReporter, false );
 
         consoleLogger = mock( ConsoleLogger.class );
     }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
@@ -392,6 +392,12 @@ public class MojoMocklessTest
         }
 
         @Override
+        protected boolean isReportAllClass()
+        {
+            return false;
+        }
+
+        @Override
         public boolean isSkipTests()
         {
             return false;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
@@ -156,7 +156,8 @@ public class ForkStarterTest
             .thenReturn( cli );
 
         StartupReportConfiguration startupReportConfiguration = new StartupReportConfiguration( true, true, null,
-            false, tmp, true, "", null, false, 0, null, null, true, null, null, null );
+            false, tmp, true, "", null, false, 0, null,
+            null, true, null, null, null, false );
 
         ConsoleLogger logger = mock( ConsoleLogger.class );
 
@@ -215,7 +216,9 @@ public class ForkStarterTest
             .thenReturn( cli );
 
         StartupReportConfiguration startupReportConfiguration = new StartupReportConfiguration( true, true, null,
-            false, tmp, true, "", null, false, 0, null, null, true, null, null, null );
+            false, tmp, true, "", null, false,
+            0, null, null, true, null,
+            null, null, false );
 
         ConsoleLogger logger = mock( ConsoleLogger.class );
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
@@ -60,6 +60,6 @@ public class TestSetMockReporterFactory
         File statisticsFile = new File( target, "TESTHASH" );
         return new StartupReportConfiguration( true, true, "PLAIN", false, target, false, null, statisticsFile,
                 false, 0, null, null, true, new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                new SurefireStatelessTestsetInfoReporter() );
+                new SurefireStatelessTestsetInfoReporter(), false );
     }
 }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StatelessReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StatelessReporterTest.java
@@ -78,7 +78,7 @@ public class StatelessReporterTest
         Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new HashMap<>();
         DefaultStatelessReportMojoConfiguration config =
                 new DefaultStatelessReportMojoConfiguration( reportsDirectory, reportNameSuffix, true, 5, schema,
-                        testClassMethodRunHistory );
+                        testClassMethodRunHistory, false );
         SurefireStatelessReporter extension = new SurefireStatelessReporter();
 
         assertThat( extension.getVersion() )
@@ -175,7 +175,7 @@ public class StatelessReporterTest
         Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new HashMap<>();
         DefaultStatelessReportMojoConfiguration config =
                 new DefaultStatelessReportMojoConfiguration( reportsDirectory, reportNameSuffix, true, 5, schema,
-                        testClassMethodRunHistory );
+                        testClassMethodRunHistory, false );
         JUnit5Xml30StatelessReporter extension = new JUnit5Xml30StatelessReporter();
 
         assertThat( extension.getVersion() )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -84,7 +84,7 @@ public class DefaultReporterFactoryTest
                 new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory, false, null,
                         new File( reportsDirectory, "TESTHASH" ), false, 1, null, null, false,
                         new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                        new SurefireStatelessTestsetInfoReporter() );
+                        new SurefireStatelessTestsetInfoReporter(), false );
 
         DummyTestReporter reporter = new DummyTestReporter();
 
@@ -280,7 +280,7 @@ public class DefaultReporterFactoryTest
                 new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory, false, null,
                         new File( reportsDirectory, "TESTHASH" ), false, 1, null, null, false,
                         new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                        new SurefireStatelessTestsetInfoReporter() );
+                        new SurefireStatelessTestsetInfoReporter() , false );
 
         DummyTestReporter reporter = new DummyTestReporter();
 
@@ -333,7 +333,7 @@ public class DefaultReporterFactoryTest
                 new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory, false, null,
                         new File( reportsDirectory, "TESTHASH" ), false, 0, null, null, false,
                         new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                        new SurefireStatelessTestsetInfoReporter() );
+                        new SurefireStatelessTestsetInfoReporter(), false );
 
         assertTrue( reportConfig.isUseFile() );
         assertTrue( reportConfig.isPrintSummary() );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -103,7 +103,7 @@ public class StatelessXmlReporterTest
         StatelessXmlReporter reporter =
                 new StatelessXmlReporter( reportDir, null, false, 0,
                         new ConcurrentHashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0",
-                        false, false, false, false );
+                        false, false, false, false, false );
         reporter.cleanTestHistoryMap();
 
         ReportEntry reportEntry = new SimpleReportEntry( getClass().getName(), null, getClass().getName(), null, 12 );
@@ -153,7 +153,8 @@ public class StatelessXmlReporterTest
 
         stats.testSucceeded( t2 );
         StatelessXmlReporter reporter = new StatelessXmlReporter( reportDir, null, false, 0,
-                new ConcurrentHashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false, false, false, false );
+                new ConcurrentHashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false,
+            false, false, false, false );
         reporter.testSetCompleted( testSetReportEntry, stats );
 
         FileInputStream fileInputStream = new FileInputStream( expectedReportFile );
@@ -232,7 +233,8 @@ public class StatelessXmlReporterTest
 
         StatelessXmlReporter reporter =
                 new StatelessXmlReporter( reportDir, null, false, 1,
-                        new HashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false, false, false, false );
+                        new HashMap<String, Deque<WrappedReportEntry>>(), XSD, "3.0", false,
+                    false, false, false, false );
 
         reporter.testSetCompleted( testSetReportEntry, stats );
         reporter.testSetCompleted( testSetReportEntry, rerunStats );

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -255,6 +255,13 @@ public class SurefirePlugin
     private int rerunFailingTestsCount;
 
     /**
+     * Set this to true to get all XML report printed into TEST-ALLCLASS.xml which consists the order of all test
+     * classes. The property is ommited for concision.
+     */
+    @Parameter( property = "surefire.reportAllClass", defaultValue = "false" )
+    private boolean reportAllClass;
+
+    /**
      * Set this to a value greater than 0 to fail the whole test set if the cumulative number of flakes reaches
      * this threshold. Set to 0 to allow an unlimited number of flakes.
      *
@@ -486,6 +493,12 @@ public class SurefirePlugin
     protected int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    @Override
+    protected boolean isReportAllClass()
+    {
+        return reportAllClass;
     }
 
     @Override

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportMojoConfiguration.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportMojoConfiguration.java
@@ -34,18 +34,22 @@ public class StatelessReportMojoConfiguration
 
     private final boolean trimStackTrace;
 
+    private final boolean reportAllClass;
+
     private final int rerunFailingTestsCount;
 
     private final String xsdSchemaLocation;
 
     public StatelessReportMojoConfiguration( File reportsDirectory, String reportNameSuffix, boolean trimStackTrace,
-                                             int rerunFailingTestsCount, String xsdSchemaLocation )
+                                             int rerunFailingTestsCount, String xsdSchemaLocation,
+                                             boolean reportAllClass )
     {
         this.reportsDirectory = reportsDirectory;
         this.reportNameSuffix = reportNameSuffix;
         this.trimStackTrace = trimStackTrace;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
         this.xsdSchemaLocation = xsdSchemaLocation;
+        this.reportAllClass = reportAllClass;
     }
 
     public File getReportsDirectory()
@@ -66,6 +70,11 @@ public class StatelessReportMojoConfiguration
     public int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    public boolean isReportAllClass ()
+    {
+        return reportAllClass;
     }
 
     public String getXsdSchemaLocation()

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
@@ -109,6 +109,6 @@ public class JUnitCoreTester
         File statisticsFile = new File( target, "TESTHASHxXML" );
         return new StartupReportConfiguration( true, true, "PLAIN", false, target, false, null, statisticsFile,
                 false, 0, null, null, false, new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                new SurefireStatelessTestsetInfoReporter() );
+                new SurefireStatelessTestsetInfoReporter(), false );
     }
 }


### PR DESCRIPTION
With `-Dsurefire.reportAllClass=true` all the content of original XML report of each class can be printed into `TEST-ALLCLASS.xml`. 
e.g. if I run `mvn test -pl ClassB,ClassA,ClassC`, then this feature outputs one file (TEST-ALLCLASS.xml) that first contains the test method results of ClassB, then the results of ClassA, then ClassC.

With this parameter, the order of each class can be collected without parsing the console log.
